### PR TITLE
detail: Switch to inverting the cmd to run instead of quoting

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,9 +5,9 @@ exports.color = color
 const ccs = require('console-control-strings')
 
 const severityColors = {
-  critical: 'magenta',
-  high: 'red',
-  moderate: 'yellow',
+  critical: 'brightMagenta',
+  high: 'brightRed',
+  moderate: 'brightYellow',
   low: null
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,29 +1,20 @@
 'use strict'
+exports.severityLabel = severityLabel
+exports.color = color
 
-const colors = require('ansicolors')
+const ccs = require('console-control-strings')
 
 const severityColors = {
-  critical: colors.magenta,
-  high: colors.red,
-  moderate: colors.yellow,
-  low: function (str) { return str }
+  critical: 'magenta',
+  high: 'red',
+  moderate: 'yellow',
+  low: null
 }
 
-const severityLabel = function (sev, withColor) {
-  if (withColor) {
-    return severityColors[sev](sev)
-  }
-  return sev
+function color (value, colorName, withColor) {
+  return (colorName && withColor) ? ccs.color(colorName) + value + ccs.color('reset') : value
 }
 
-const color = function (value, color, withColor) {
-  if (withColor) {
-    return colors[color](value)
-  }
-  return value
-}
-
-module.exports = {
-  severityLabel: severityLabel,
-  color: color
+function severityLabel (sev, withColor) {
+  return color(sev, severityColors[sev], withColor)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,11 +62,6 @@
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
-    "ansistyles": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
-      "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk="
-    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,11 +62,6 @@
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
-    "ansicolors": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-      "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk="
-    },
     "ansistyles": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
@@ -391,6 +386,11 @@
         "readable-stream": "2.3.4",
         "typedarray": "0.0.6"
       }
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "contains-path": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "author": "Adam Baldwin",
   "license": "ISC",
   "dependencies": {
-    "ansistyles": "^0.1.3",
     "cli-table2": "^0.2.0",
     "console-control-strings": "^1.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   "author": "Adam Baldwin",
   "license": "ISC",
   "dependencies": {
-    "ansicolors": "^0.3.2",
     "ansistyles": "^0.1.3",
-    "cli-table2": "^0.2.0"
+    "cli-table2": "^0.2.0",
+    "console-control-strings": "^1.1.0"
   },
   "devDependencies": {
     "keyfob": "^1.0.0",

--- a/reporters/detail.js
+++ b/reporters/detail.js
@@ -55,10 +55,10 @@ const report = function (data, options) {
       exit = 1
     }
     if (total === 0) {
-      log(`${Utils.color('[+]', 'green', config.withColor)} no known vulnerabilities found`)
+      log(`${Utils.color('[+]', 'brightGreen', config.withColor)} no known vulnerabilities found`)
       log(`    Packages audited: ${data.metadata.totalDependencies} (${data.metadata.devDependencies} dev, ${data.metadata.optionalDependencies} optional)`)
     } else {
-      log(`\n${Utils.color('[!]', 'red', config.withColor)} ${total} ${total === 1 ? 'vulnerability' : 'vulnerabilities'} found - Packages audited: ${data.metadata.totalDependencies} (${data.metadata.devDependencies} dev, ${data.metadata.optionalDependencies} optional)`)
+      log(`\n${Utils.color('[!]', 'brightRed', config.withColor)} ${total} ${total === 1 ? 'vulnerability' : 'vulnerabilities'} found - Packages audited: ${data.metadata.totalDependencies} (${data.metadata.devDependencies} dev, ${data.metadata.optionalDependencies} optional)`)
       log(`    Severity: ${severities}`)
     }
   }

--- a/reporters/detail.js
+++ b/reporters/detail.js
@@ -92,7 +92,7 @@ const report = function (data, options) {
         if (action.action === 'update' || action.action === 'install') {
           const recommendation = getRecommendation(action, config)
           const label = action.resolves.length === 1 ? 'vulnerability' : 'vulnerabilities'
-          log(`\n\n# Run \`${Utils.color(recommendation.cmd, 'red', config.withColor)}\` to resolve ${action.resolves.length} ${label}`)
+          log(`\n\n# Run ${Utils.color(' ' + recommendation.cmd + ' ', 'inverse', config.withColor)} to resolve ${action.resolves.length} ${label}`)
           if (recommendation.isBreaking) {
             log(`SEMVER WARNING: Recommended action is a potentially breaking change`)
           }

--- a/reporters/install.js
+++ b/reporters/install.js
@@ -16,7 +16,7 @@ const report = function (data, options) {
   }
 
   if (Object.keys(data.advisories).length === 0) {
-    log(`${Utils.color('[+]', 'green', config.withColor)} no known vulnerabilities found [${data.metadata.totalDependencies} packages audited]`)
+    log(`${Utils.color('[+]', 'brightGreen', config.withColor)} no known vulnerabilities found [${data.metadata.totalDependencies} packages audited]`)
     return {
       report: output,
       exitCode: 0
@@ -37,7 +37,7 @@ const report = function (data, options) {
       return `${value[1]} ${Utils.severityLabel(value[0], false)}`
     }).join(' | ')
 
-    log(`${Utils.color('[!]', 'red', config.withColor)} ${total} ${total === 1 ? 'vulnerability' : 'vulnerabilities'} found [${data.metadata.totalDependencies} packages audited]`)
+    log(`${Utils.color('[!]', 'brightRed', config.withColor)} ${total} ${total === 1 ? 'vulnerability' : 'vulnerabilities'} found [${data.metadata.totalDependencies} packages audited]`)
     log(`    Severity: ${severities}`)
     log(`    Run \`npm audit\` for more detail`)
     return {

--- a/test/detail-report-test.js
+++ b/test/detail-report-test.js
@@ -46,7 +46,7 @@ tap.test('it generates a detail report with one vuln (review dev dep)', function
 tap.test('it generates a detail report with one vuln, no color', function (t) {
   return Report(fixtures['one-vuln'], {reporter: 'detail', withColor: false}).then((report) => {
     t.match(report.exitCode, 1)
-    t.match(report.report, /# Run `npm update tough-cookie --depth 6` to resolve 1 vulnerability/)
+    t.match(report.report, /# Run  npm update tough-cookie --depth 6  to resolve 1 vulnerability/)
   })
 })
 


### PR DESCRIPTION
The idea here is that this way double clicking the command to run will never pick up backticks. It's also substantially more visible.

I swapped from `ansicolors` to my own `console-control-strings` for this to get the invert codes.

I ah, also ended up rewriting `lib/utils.js`l a bit. 😅🙏

Anyway, this is what it looks like (in Terminal and iTerm2):

<img width="1217" alt="updated" src="https://user-images.githubusercontent.com/983798/39402678-f4da8204-4b1a-11e8-89a1-6a4852816452.png">
