### PR TITLE
Fix install flag for dev dependencies

### DIFF
--- a/reporters/detail.js
+++ b/reporters/detail.js
@@ -176,7 +176,7 @@ const getRecommendation = function (action, config) {
     const isDev = action.resolves[0].dev
 
     return {
-      cmd: `npm install ${isDev ? '--dev ' : ''}${action.module}@${action.target}`,
+      cmd: `npm install ${isDev ? '--save-dev ' : ''}${action.module}@${action.target}`,
       isBreaking: action.isMajor
     }
   } else {

--- a/test/detail-report-test.js
+++ b/test/detail-report-test.js
@@ -31,7 +31,7 @@ tap.test('it generates a detail report with one vuln (install action)', function
 tap.test('it generates a detail report with one vuln (install dev dep)', function (t) {
   return Report(fixtures['one-vuln-dev'], {reporter: 'detail'}).then((report) => {
     t.match(report.exitCode, 1)
-    t.match(report.report, /npm install --dev knex@3.0.0/)
+    t.match(report.report, /npm install --save-dev knex@3.0.0/)
   })
 })
 


### PR DESCRIPTION
According to [docs](https://docs.npmjs.com/cli/install) the correct flag for dev dependencies is `--save-dev`, not `--dev`.

Running the code with `--dev` results in the following error:
```
npm WARN install Usage of the `--dev` option is deprecated. Use `--only=dev` instead.
```