### PR TITLE
Adding options table + improving example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ The response is an object that contains an output string (the report) and a sugg
 ```
 'use strict'
 const Report = require('npm-audit-report')
+const options = {
+  reporter: 'json'
+}
 
 Report(response, options, (result) => {
   console.log(result.report)
@@ -30,16 +33,8 @@ Report(response, options, (result) => {
 
 ## options
 
-reporter: 
-  specify which output format you want to use (install, detail, json)
-
-withColor: 
-  true || false indicates if some report elements should use colors or not
-
-withUnicode: 
-  true || false indicates if unicode characters should be used or not.
-
-
-
-
-
+| option        | values                               | default   | description |
+| :---          | :---                                 | :---      |:--- |
+| reporter      | `install`, `detail`, `json`, `quiet` | `install` | specify which output format you want to use |
+| withColor     | `true`, `false`                      | `true`    | indicates if some report elements should use colors |
+| withUnicode   | `true`, `false`                      | `true`    | indicates if unicode characters should be used |


### PR DESCRIPTION
- displaying options in a table
- adding missing 'quiet' reporter
- extending example with an options object

Best reviewed [here](https://github.com/mdix/npm-audit-report/blob/update-documentation/README.md#basic-usage-example).