### PR TITLE
Test utils

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -29,6 +29,7 @@ function color (value, colorName, withColor) {
 }
 
 function severityLabel (sev, withColor, bold) {
+  if (!(sev in severityColors)) return sev.charAt(0).toUpperCase() + sev.substr(1).toLowerCase()
   let colorName = severityColors[sev].color
   if (bold) colorName = [colorName, 'bold']
   return color(severityColors[sev].label, colorName, withColor)

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -3,9 +3,11 @@
 const tap = require('tap')
 const {severityLabel, color} = require('../lib/utils')
 
-tap.test('color does just return the value if colorName and withColor are missing', function (t) {
+tap.test('color does just return the value if colorName AND withColor are missing', function (t) {
   t.equal(color('Low'), 'Low')
   t.equal(color('something'), 'something')
+  t.equal(color('something', 'brightRed'), 'something')
+  t.equal(color('something', null, true), 'something')
   t.done()
 })
 
@@ -16,6 +18,6 @@ tap.test('color returns a formatted string if all params are set', function (t) 
 })
 
 tap.test('severity does not throw an error if given severity is not defined', function (t) {
-  t.throws(function () { severityLabel('me-no-exist') })
+  t.doesNotThrow(function () { severityLabel('me-no-exist') })
   t.done()
 })

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const tap = require('tap')
+const {severityLabel, color} = require('../lib/utils')
+
+tap.test('color does just return the value if colorName and withColor are missing', function (t) {
+  t.equal(color('Low'), 'Low')
+  t.equal(color('something'), 'something')
+  t.done()
+})
+
+tap.test('color returns a formatted string if all params are set', function (t) {
+  t.equal(color('Low', 'brightGreen', true), '\x1b[92mLow\x1b[0m')
+  t.equal(color('High', 'brightRed', true), '\x1b[91mHigh\x1b[0m')
+  t.done()
+})
+
+tap.test('severity does not throw an error if given severity is not defined', function (t) {
+  t.throws(function () { severityLabel('me-no-exist') })
+  t.done()
+})

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -12,12 +12,24 @@ tap.test('color does just return the value if colorName AND withColor are missin
 })
 
 tap.test('color returns a formatted string if all params are set', function (t) {
-  t.equal(color('Low', 'brightGreen', true), '\x1b[92mLow\x1b[0m')
-  t.equal(color('High', 'brightRed', true), '\x1b[91mHigh\x1b[0m')
+  t.equal(color('Low', 'brightGreen', true), '\u001b[92mLow\u001b[0m')
+  t.equal(color('High', 'brightRed', true), '\u001b[91mHigh\u001b[0m')
   t.done()
 })
 
 tap.test('severity does not throw an error if given severity is not defined', function (t) {
   t.doesNotThrow(function () { severityLabel('me-no-exist') })
+  t.done()
+})
+
+tap.test('severity returns a label if there is no color mapping', function (t) {
+  t.equal(severityLabel('me-no-exist'), 'Me-no-exist')
+  t.equal(severityLabel('w000000t'), 'W000000t')
+  t.done()
+})
+
+tap.test('severity returns a label with color formatting ', function (t) {
+  t.equal(severityLabel('high', true, true), '\u001b[91;1mHigh\u001b[0m')
+  t.equal(severityLabel('low', true, true), '\u001b[1;1mLow\u001b[0m')
   t.done()
 })


### PR DESCRIPTION
As @welwood08 pointed out [here](https://github.com/npm/npm-audit-report/pull/18#issuecomment-393015808), it's a good idea to check if there's a color mapping for the given severity. I used his implementation (thanks @welwood08) and while I was at it, added some tests that test the `util` functions. To some degree it also tests the library that is used (console-control-strings), but I didn't want to add complexity by mocking it.

**Failing test**
https://github.com/npm/npm-audit-report/commit/d1a5a497da868fa8ee079ac8041934d393a9a45c#diff-217c8c4d2e8bfad83bb50eb212294249R21

**Implementation**
https://github.com/npm/npm-audit-report/commit/dfea1d031947bdf89f24b77ad7b70f4e3c463dbb#diff-50e3aa130a4f97a42ee2cf111c7b1d9dR32