### PR TITLE
a test should not cause side-effects in other tests

### DIFF
--- a/test/detail-report-test.js
+++ b/test/detail-report-test.js
@@ -2,9 +2,7 @@
 
 const tap = require('tap')
 const Report = require('../')
-const Keyfob = require('keyfob')
-
-const fixtures = Keyfob.load({ path: 'test/fixtures', fn: require })
+const fixtures = require('./lib/test-fixtures')
 
 tap.test('it generates a detail report with no vulns', function (t) {
   return Report(fixtures['no-vulns'], {reporter: 'detail', withColor: false}).then((report) => {

--- a/test/install-report-test.js
+++ b/test/install-report-test.js
@@ -2,9 +2,7 @@
 
 const tap = require('tap')
 const Report = require('../')
-const Keyfob = require('keyfob')
-
-const fixtures = Keyfob.load({ path: 'test/fixtures', fn: require })
+const fixtures = require('./lib/test-fixtures')
 
 tap.test('it generates an install report with no vulns', function (t) {
   return Report(fixtures['no-vulns']).then((report) => {

--- a/test/json-report-test.js
+++ b/test/json-report-test.js
@@ -2,9 +2,7 @@
 
 const tap = require('tap')
 const Report = require('../')
-const Keyfob = require('keyfob')
-
-const fixtures = Keyfob.load({ path: 'test/fixtures', fn: require })
+const fixtures = require('./lib/test-fixtures')
 
 tap.test('it generates a json report', function (t) {
   return Report(fixtures['no-vulns'], {reporter: 'json'}).then((report) => {

--- a/test/lib/test-fixtures.js
+++ b/test/lib/test-fixtures.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const Keyfob = require('keyfob')
+
+const fixtures = module.exports = Keyfob.load({ path: 'test/fixtures' })
+Object.keys(fixtures).forEach(name => {
+  const content = fixtures[name]
+  Object.defineProperty(fixtures, name, {
+    get: () => JSON.parse(content)
+  })
+})

--- a/test/quiet-report-test.js
+++ b/test/quiet-report-test.js
@@ -2,9 +2,7 @@
 
 const tap = require('tap')
 const Report = require('../')
-const Keyfob = require('keyfob')
-
-const fixtures = Keyfob.load({ path: 'test/fixtures', fn: require })
+const fixtures = require('./lib/test-fixtures')
 
 tap.test('it generates an quiet report with no vulns', function (t) {
   return Report(fixtures['no-vulns'], {reporter: 'quiet'}).then((report) => {

--- a/test/test-fixtures-test.js
+++ b/test/test-fixtures-test.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const tap = require('tap')
+const fixtures = require('./lib/test-fixtures')
+
+tap.test('a test should be able to modify a fixture', function (t) {
+  const fixture = fixtures['one-vuln']
+  fixture.actions.splice(0, 1)
+  delete fixture.muted
+  fixture.metadata.vulnerabilities.high = 0
+  t.equal(fixture.actions.length, 0)
+  t.is('muted' in fixture, false)
+  t.same(fixture.metadata.vulnerabilities, {
+    info: 0,
+    low: 0,
+    moderate: 0,
+    high: 0,
+    critical: 0
+  })
+  t.end()
+})
+
+tap.test('a test should not be able to see how a previous test modified a fixture', function (t) {
+  const fixture = fixtures['one-vuln']
+  t.equal(fixture.actions.length, 1)
+  t.is('muted' in fixture, true)
+  t.same(fixture.metadata.vulnerabilities, {
+    info: 0,
+    low: 0,
+    moderate: 0,
+    high: 1,
+    critical: 0
+  })
+  t.end()
+})


### PR DESCRIPTION
If a fixture object was modified in one test, the modification would be visible
to other tests using the same fixture object.

I encountered this problem whilst testing an upcoming PR. This change makes
every usage of a fixture a new object. I'm open to suggestions on alternative
solutions, such as specifying that fixture modification is a test failure.