### PR TITLE
Update `cli-table2` to `cli-table3`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -384,14 +384,43 @@
         "restore-cursor": "^2.0.0"
       }
     },
-    "cli-table2": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/cli-table2/-/cli-table2-0.2.0.tgz",
-      "integrity": "sha1-LR738hig54biFFQFYtS9F3/jLZc=",
+    "cli-table3": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.0.tgz",
+      "integrity": "sha512-c7YHpUyO1SaKaO7kYtxd5NZ8FjAmSK3LpKkuzdwn+2CwpFxBpdoQLm+OAnnCfoEl7onKhN9PKQi1lsHuAIUqGQ==",
       "requires": {
         "colors": "^1.1.2",
-        "lodash": "^3.10.1",
-        "string-width": "^1.0.1"
+        "object-assign": "^4.1.0",
+        "string-width": "^2.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
       }
     },
     "cli-width": {
@@ -2488,11 +2517,6 @@
           "dev": true
         }
       }
-    },
-    "lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Adam Baldwin",
   "license": "ISC",
   "dependencies": {
-    "cli-table2": "^0.2.0",
+    "cli-table3": "^0.5.0",
     "console-control-strings": "^1.1.0"
   },
   "devDependencies": {

--- a/reporters/detail.js
+++ b/reporters/detail.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const summary = require('./install.js').summary
-const Table = require('cli-table2')
+const Table = require('cli-table3')
 const Utils = require('../lib/utils')
 
 const report = function (data, options) {


### PR DESCRIPTION
This PR updates the `cli-table2` dependency to `cli-table3`, which fixes one of the `npm audit` warnings

similar to https://github.com/npm/npm/pull/20955