### PR TITLE
Filtering of vulnerabilities

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,7 +2,7 @@
 
 const ccs = require('console-control-strings')
 
-const severityColors = {
+const severityMetadata = {
   critical: {
     color: 'brightMagenta',
     label: 'Critical'
@@ -24,16 +24,28 @@ const severityColors = {
     label: 'Info'
   }
 }
+const severityOrder = ['critical', 'high', 'moderate', 'low', 'info']
+severityOrder.forEach((severity, order) => {
+  severityMetadata[severity].order = order
+})
 
 const color = exports.color = function (value, colorName, withColor) {
   return (colorName && withColor) ? ccs.color(colorName) + value + ccs.color('reset') : value
 }
 
 const severityLabel = exports.severityLabel = function (sev, withColor, bold) {
-  if (!(sev in severityColors)) return sev.charAt(0).toUpperCase() + sev.substr(1).toLowerCase()
-  let colorName = severityColors[sev].color
+  if (!(sev in severityMetadata)) return sev.charAt(0).toUpperCase() + sev.substr(1).toLowerCase()
+  let colorName = severityMetadata[sev].color
   if (bold) colorName = [colorName, 'bold']
-  return color(severityColors[sev].label, colorName, withColor)
+  return color(severityMetadata[sev].label, colorName, withColor)
+}
+
+const severityCompare = exports.severityCompare = function (a, b) {
+  a = a.severity || a
+  b = b.severity || b
+  const oA = a in severityMetadata ? severityMetadata[a].order : -1
+  const oB = b in severityMetadata ? severityMetadata[b].order : -1
+  return oA - oB
 }
 
 exports.vulnTotal = function (vulns) {
@@ -74,13 +86,15 @@ exports.vulnSummary = function (vulns, config) {
 exports.vulnFilter = function (data, config) {
   config = Object.assign({
     excludeDev: false,
-    excludeProd: false
+    excludeProd: false,
+    severityThreshold: 'info'
   }, config)
   data.actions.forEach((action) => {
     action.resolves = action.resolves.filter(({id, dev}) => {
-      const exclude = config[dev ? 'excludeDev' : 'excludeProd']
+      const severity = data.advisories[id].severity
+      const excludeSeverity = severityCompare(config.severityThreshold, severity) < 0
+      const exclude = config[dev ? 'excludeDev' : 'excludeProd'] || excludeSeverity
       if (exclude) {
-        const severity = data.advisories[id].severity
         data.metadata.vulnerabilities[severity]--
         data.metadata.excluded = data.metadata.excluded || {}
         data.metadata.excluded[severity] = (data.metadata.excluded[severity] || 0) + 1

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,10 +1,5 @@
 'use strict'
 
-exports.severityLabel = severityLabel
-exports.color = color
-exports.totalVulnCount = totalVulnCount
-exports.severities = severities
-
 const ccs = require('console-control-strings')
 
 const severityColors = {
@@ -30,31 +25,73 @@ const severityColors = {
   }
 }
 
-function color (value, colorName, withColor) {
+const color = exports.color = function (value, colorName, withColor) {
   return (colorName && withColor) ? ccs.color(colorName) + value + ccs.color('reset') : value
 }
 
-function severityLabel (sev, withColor, bold) {
+const severityLabel = exports.severityLabel = function (sev, withColor, bold) {
   if (!(sev in severityColors)) return sev.charAt(0).toUpperCase() + sev.substr(1).toLowerCase()
   let colorName = severityColors[sev].color
   if (bold) colorName = [colorName, 'bold']
   return color(severityColors[sev].label, colorName, withColor)
 }
 
-function totalVulnCount (vulns) {
-  return Object.keys(vulns).reduce((accumulator, key) => {
-    const vulnCount = vulns[key]
+exports.vulnTotal = function (vulns) {
+  return Object.keys(vulns).reduce((accumulator, severity) => {
+    const vulnCount = vulns[severity]
     accumulator += vulnCount
 
     return accumulator
   }, 0)
 }
 
-function severities (vulns) {
+exports.vulnSummary = function (vulns, config) {
+  config = Object.assign({}, config)
+  const summary = {
+    total: 0
+  }
+
+  const sev = Object.keys(vulns).reduce((accumulator, severity) => {
+    const vulnCount = vulns[severity]
+    if (vulnCount > 0) {
+      summary.total += vulnCount
+      accumulator.push(`${vulnCount} ${severityLabel(severity, config.withColor).toLowerCase()}`)
+    }
+    return accumulator
+  }, [])
+
+  if (summary.total === 0) {
+    summary.msg = `found ${color('0', 'brightGreen', config.withColor)} vulnerabilities`
+  } else if (sev.length === 1) {
+    summary.msg = `found ${sev[0]} severity vulnerabilit${summary.total === 1 ? 'y' : 'ies'}`
+  } else {
+    summary.msg = `found ${color(summary.total, 'brightRed', config.withColor)} vulnerabilities (${sev.join(', ')})`
+  }
+
+  return summary
+}
+
+exports.severities = function (vulns) {
   return Object.keys(vulns).reduce((accumulator, severity) => {
     const vulnCount = vulns[severity]
     if (vulnCount > 0) accumulator.push([severity, vulnCount])
 
     return accumulator
   }, [])
+}
+
+exports.getRecommendation = function (action, config) {
+  if (action.action === 'install') {
+    const isDev = action.resolves[0].dev
+
+    return {
+      cmd: `npm install ${isDev ? '--save-dev ' : ''}${action.module}@${action.target}`,
+      isBreaking: action.isMajor
+    }
+  } else {
+    return {
+      cmd: `npm update ${action.module} --depth ${action.depth}`,
+      isBreaking: false
+    }
+  }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -71,6 +71,25 @@ exports.vulnSummary = function (vulns, config) {
   return summary
 }
 
+exports.vulnFilter = function (data, config) {
+  config = Object.assign({
+    excludeDev: false,
+    excludeProd: false
+  }, config)
+  data.actions.forEach((action) => {
+    action.resolves = action.resolves.filter(({id, dev}) => {
+      const exclude = config[dev ? 'excludeDev' : 'excludeProd']
+      if (exclude) {
+        const severity = data.advisories[id].severity
+        data.metadata.vulnerabilities[severity]--
+        data.metadata.excluded = data.metadata.excluded || {}
+        data.metadata.excluded[severity] = (data.metadata.excluded[severity] || 0) + 1
+      }
+      return !exclude
+    })
+  })
+}
+
 exports.severities = function (vulns) {
   return Object.keys(vulns).reduce((accumulator, severity) => {
     const vulnCount = vulns[severity]

--- a/reporters/detail.js
+++ b/reporters/detail.js
@@ -28,19 +28,90 @@ const report = function (data, options) {
 
   const config = Object.assign({}, defaults, options)
 
-  let output = ''
-  let exit = 0
+  let output = []
 
   const log = function (value) {
-    output = output + value + '\n'
+    output.push(value)
+  }
+
+  const summary = Utils.vulnSummary(data.metadata.vulnerabilities, config)
+
+  const header = function () {
+    const tableOptions = {
+      colWidths: [78]
+    }
+    tableOptions.chars = blankChars
+    const table = new Table(tableOptions)
+    table.push([{
+      content: '=== npm audit security report ===',
+      vAlign: 'center',
+      hAlign: 'center'
+    }])
+    log(table.toString())
+  }
+
+  const actions = function (data, config) {
+    let reviewFlag = false
+
+    data.actions.forEach((action) => {
+      if (action.action === 'update' || action.action === 'install') {
+        const recommendation = Utils.getRecommendation(action, config)
+        const label = action.resolves.length === 1 ? 'vulnerability' : 'vulnerabilities'
+        log(`# Run ${Utils.color(' ' + recommendation.cmd + ' ', 'inverse', config.withColor)} to resolve ${action.resolves.length} ${label}`)
+        if (recommendation.isBreaking) {
+          log(`SEMVER WARNING: Recommended action is a potentially breaking change`)
+        }
+      }
+      if (action.action === 'review' && !reviewFlag) {
+        const tableOptions = {
+          colWidths: [78]
+        }
+        if (!config.withUnicode) {
+          tableOptions.chars = blankChars
+        }
+        const table = new Table(tableOptions)
+        table.push([{
+          content: 'Manual Review\nSome vulnerabilities require your attention to resolve\n\nVisit https://go.npm.me/audit-guide for additional guidance',
+          vAlign: 'center',
+          hAlign: 'center'
+        }])
+
+        log(table.toString())
+        reviewFlag = true
+      }
+
+      action.resolves.forEach((resolution) => {
+        const advisory = data.advisories[resolution.id]
+        const tableOptions = {
+          colWidths: [15, 62],
+          wordWrap: true
+        }
+        if (!config.withUnicode) {
+          tableOptions.chars = blankChars
+        }
+        const table = new Table(tableOptions)
+
+        table.push(
+          {[Utils.severityLabel(advisory.severity, config.withColor, true)]: Utils.color(advisory.title, 'bold', config.withColor)},
+          {'Package': advisory.module_name},
+          {'Dependency of': `${resolution.path.split('>')[0]} ${resolution.dev ? '[dev]' : ''}`},
+          {'Path': `${resolution.path.split('>').join(Utils.color(' > ', 'grey', config.withColor))}`},
+          {'More info': 'https://nodesecurity.io/advisories/' + advisory.id}
+        )
+
+        if (action.action === 'review') {
+          const patchedIn = advisory.patched_versions.replace(' ', '') === '<0.0.0' ? 'No patch available' : advisory.patched_versions
+          table.splice(2, 0, {'Patched in': patchedIn})
+        }
+
+        log(table.toString() + '\n\n')
+      })
+    })
   }
 
   const footer = function (data) {
-    const summary = Utils.vulnSummary(data.metadata.vulnerabilities, config)
-
     log(`${summary.msg} in ${data.metadata.totalDependencies} scanned package${data.metadata.totalDependencies === 1 ? '' : 's'}`)
     if (summary.total) {
-      exit = 1
       const counts = data.actions.reduce((acc, {action, isMajor, resolves}) => {
         if (action === 'update' || (action === 'install' && !isMajor)) {
           resolves.forEach(({id, path}) => acc.advisories.add(`${id}::${path}`))
@@ -67,111 +138,15 @@ const report = function (data, options) {
     }
   }
 
-  const reportTitle = function () {
-    const tableOptions = {
-      colWidths: [78]
-    }
-    tableOptions.chars = blankChars
-    const table = new Table(tableOptions)
-    table.push([{
-      content: '=== npm audit security report ===',
-      vAlign: 'center',
-      hAlign: 'center'
-    }])
-    log(table.toString())
+  header()
+  if (summary.total) { // vulns found display a report.
+    actions(data, config)
   }
-
-  const actions = function (data, config) {
-    reportTitle()
-
-    if (Object.keys(data.advisories).length !== 0) {
-      // vulns found display a report.
-
-      let reviewFlag = false
-
-      data.actions.forEach((action) => {
-        if (action.action === 'update' || action.action === 'install') {
-          const recommendation = Utils.getRecommendation(action, config)
-          const label = action.resolves.length === 1 ? 'vulnerability' : 'vulnerabilities'
-          log(`# Run ${Utils.color(' ' + recommendation.cmd + ' ', 'inverse', config.withColor)} to resolve ${action.resolves.length} ${label}`)
-          if (recommendation.isBreaking) {
-            log(`SEMVER WARNING: Recommended action is a potentially breaking change`)
-          }
-
-          action.resolves.forEach((resolution) => {
-            const advisory = data.advisories[resolution.id]
-            const tableOptions = {
-              colWidths: [15, 62],
-              wordWrap: true
-            }
-            if (!config.withUnicode) {
-              tableOptions.chars = blankChars
-            }
-            const table = new Table(tableOptions)
-
-            table.push(
-              {[Utils.severityLabel(advisory.severity, config.withColor, true)]: Utils.color(advisory.title, 'bold', config.withColor)},
-              {'Package': advisory.module_name},
-              {'Dependency of': `${resolution.path.split('>')[0]} ${resolution.dev ? '[dev]' : ''}`},
-              {'Path': `${resolution.path.split('>').join(Utils.color(' > ', 'grey', config.withColor))}`},
-              {'More info': `https://nodesecurity.io/advisories/${advisory.id}`}
-            )
-
-            log(table.toString() + '\n\n')
-          })
-        }
-        if (action.action === 'review') {
-          if (!reviewFlag) {
-            const tableOptions = {
-              colWidths: [78]
-            }
-            if (!config.withUnicode) {
-              tableOptions.chars = blankChars
-            }
-            const table = new Table(tableOptions)
-            table.push([{
-              content: 'Manual Review\nSome vulnerabilities require your attention to resolve\n\nVisit https://go.npm.me/audit-guide for additional guidance',
-              vAlign: 'center',
-              hAlign: 'center'
-            }])
-
-            log(table.toString())
-          }
-          reviewFlag = true
-
-          action.resolves.forEach((resolution) => {
-            const advisory = data.advisories[resolution.id]
-            const tableOptions = {
-              colWidths: [15, 62],
-              wordWrap: true
-            }
-            if (!config.withUnicode) {
-              tableOptions.chars = blankChars
-            }
-            const table = new Table(tableOptions)
-            const patchedIn = advisory.patched_versions.replace(' ', '') === '<0.0.0' ? 'No patch available' : advisory.patched_versions
-
-            table.push(
-              {[Utils.severityLabel(advisory.severity, config.withColor, true)]: Utils.color(advisory.title, 'bold', config.withColor)},
-              {'Package': advisory.module_name},
-              {'Patched in': patchedIn},
-              {'Dependency of': `${resolution.path.split('>')[0]} ${resolution.dev ? '[dev]' : ''}`},
-              {'Path': `${resolution.path.split('>').join(Utils.color(' > ', 'grey', config.withColor))}`},
-              {'More info': `https://nodesecurity.io/advisories/${advisory.id}`}
-            )
-            log(table.toString())
-          })
-        }
-      })
-    }
-  }
-
-  actions(data, config)
   footer(data)
 
   return {
-    report: output.trim(),
-    exitCode: exit
+    report: output.join('\n').trim(),
+    exitCode: summary.total ? 1 : 0
   }
 }
 

--- a/reporters/detail.js
+++ b/reporters/detail.js
@@ -4,9 +4,7 @@ const Table = require('cli-table3')
 const Utils = require('../lib/utils')
 
 const report = function (data, options) {
-  const defaults = {
-    severityThreshold: 'info'
-  }
+  const defaults = {}
 
   const blankChars = {
     'top': ' ',

--- a/reporters/detail.js
+++ b/reporters/detail.js
@@ -34,6 +34,7 @@ const report = function (data, options) {
     output.push(value)
   }
 
+  Utils.vulnFilter(data, config)
   const summary = Utils.vulnSummary(data.metadata.vulnerabilities, config)
 
   const header = function () {

--- a/reporters/install.js
+++ b/reporters/install.js
@@ -4,58 +4,13 @@ const Utils = require('../lib/utils')
 
 module.exports = report
 function report (data, options) {
-  let msg = summary(data, options)
-  if (!Object.keys(data.advisories).length) {
-    return {
-      report: msg,
-      exitCode: 0
-    }
-  } else {
-    msg += '\n  run `npm audit fix` to fix them, or `npm audit` for details'
-    return {
-      report: msg,
-      exitCode: 1
-    }
-  }
-}
-
-module.exports.summary = summary
-function summary (data, options) {
-  const defaults = {
-    severityThreshold: 'info'
+  const summary = Utils.vulnSummary(data.metadata.vulnerabilities, options)
+  if (summary.total) {
+    summary.msg += '\n  run `npm audit fix` to fix them, or `npm audit` for details'
   }
 
-  const config = Object.assign({}, defaults, options)
-
-  function clr (str, clr) { return Utils.color(str, clr, config.withColor) }
-  function green (str) { return clr(str, 'brightGreen') }
-  function red (str) { return clr(str, 'brightRed') }
-
-  let output = ''
-
-  const log = function (value) {
-    output = output + value + '\n'
+  return {
+    report: summary.msg,
+    exitCode: summary.total ? 1 : 0
   }
-
-  output += 'found '
-
-  if (Object.keys(data.advisories).length === 0) {
-    log(`${green('0')} vulnerabilities`)
-    return output
-  } else {
-    const total = Utils.totalVulnCount(data.metadata.vulnerabilities)
-    const sev = Utils.severities(data.metadata.vulnerabilities)
-
-    if (sev.length > 1) {
-      const severities = sev.map((value) => {
-        return `${value[1]} ${Utils.severityLabel(value[0], config.withColor).toLowerCase()}`
-      }).join(', ')
-      log(`${red(total)} vulnerabilities (${severities})`)
-    } else {
-      const vulnCount = sev[0][1]
-      const vulnLabel = Utils.severityLabel(sev[0][0], config.withColor).toLowerCase()
-      log(`${vulnCount} ${vulnLabel} severity vulnerabilit${vulnCount === 1 ? 'y' : 'ies'}`)
-    }
-  }
-  return output.trim()
 }

--- a/reporters/parseable.js
+++ b/reporters/parseable.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const Utils = require('../lib/utils')
+
 const report = function (data, options) {
   const defaults = {
     severityThreshold: 'info'
@@ -21,7 +23,7 @@ const report = function (data, options) {
         let l = {}
         // Start with install/update actions
         if (action.action === 'update' || action.action === 'install') {
-          const recommendation = getRecommendation(action, config)
+          const recommendation = Utils.getRecommendation(action, config)
           l.recommendation = recommendation.cmd
           l.breaking = recommendation.isBreaking ? 'Y' : 'N'
 
@@ -74,22 +76,6 @@ const report = function (data, options) {
   return {
     report: actions(data, config),
     exitCode: exit
-  }
-}
-
-const getRecommendation = function (action, config) {
-  if (action.action === 'install') {
-    const isDev = action.resolves[0].dev
-
-    return {
-      cmd: `npm install ${isDev ? '--save-dev ' : ''}${action.module}@${action.target}`,
-      isBreaking: action.isMajor
-    }
-  } else {
-    return {
-      cmd: `npm update ${action.module} --depth ${action.depth}`,
-      isBreaking: false
-    }
   }
 }
 

--- a/reporters/parseable.js
+++ b/reporters/parseable.js
@@ -9,6 +9,7 @@ const report = function (data, options) {
 
   const config = Object.assign({}, defaults, options)
 
+  Utils.vulnFilter(data, config)
   const vulnTotal = Utils.vulnTotal(data.metadata.vulnerabilities)
 
   const actions = function (data, config) {
@@ -46,7 +47,7 @@ const report = function (data, options) {
   }
 
   return {
-    report: actions(data, config),
+    report: vulnTotal ? actions(data, config) : '',
     exitCode: vulnTotal ? 1 : 0
   }
 }

--- a/reporters/parseable.js
+++ b/reporters/parseable.js
@@ -3,9 +3,7 @@
 const Utils = require('../lib/utils')
 
 const report = function (data, options) {
-  const defaults = {
-    severityThreshold: 'info'
-  }
+  const defaults = {}
 
   const config = Object.assign({}, defaults, options)
 

--- a/reporters/quiet.js
+++ b/reporters/quiet.js
@@ -3,7 +3,7 @@
 const Utils = require('../lib/utils')
 
 const report = function (data) {
-  const totalVulnCount = Utils.totalVulnCount(data.metadata.vulnerabilities)
+  const totalVulnCount = Utils.vulnTotal(data.metadata.vulnerabilities)
 
   return {
     report: '',

--- a/reporters/quiet.js
+++ b/reporters/quiet.js
@@ -2,7 +2,8 @@
 
 const Utils = require('../lib/utils')
 
-const report = function (data) {
+const report = function (data, config) {
+  Utils.vulnFilter(data, config)
   const vulnTotal = Utils.vulnTotal(data.metadata.vulnerabilities)
 
   return {

--- a/reporters/quiet.js
+++ b/reporters/quiet.js
@@ -3,11 +3,11 @@
 const Utils = require('../lib/utils')
 
 const report = function (data) {
-  const totalVulnCount = Utils.vulnTotal(data.metadata.vulnerabilities)
+  const vulnTotal = Utils.vulnTotal(data.metadata.vulnerabilities)
 
   return {
     report: '',
-    exitCode: totalVulnCount === 0 ? 0 : 1
+    exitCode: vulnTotal ? 1 : 0
   }
 }
 

--- a/test/detail-report-test.js
+++ b/test/detail-report-test.js
@@ -6,7 +6,7 @@ const fixtures = require('./lib/test-fixtures')
 
 tap.test('it generates a detail report with no vulns', function (t) {
   return Report(fixtures['no-vulns'], {reporter: 'detail', withColor: false}).then((report) => {
-    t.match(report.exitCode, 0, 'successful exit code')
+    t.equal(report.exitCode, 0, 'successful exit code')
     t.match(report.report, /found 0 vulnerabilities/, 'no vulns reported')
     t.match(report.report, /918 scanned packages/, 'reports scanned count')
   })

--- a/test/detail-report-test.js
+++ b/test/detail-report-test.js
@@ -108,3 +108,19 @@ tap.test('it generates a detail report with no vulns when a dev dep has a vuln a
     t.match(report.report, /918 scanned packages/, 'reports scanned count')
   })
 })
+
+tap.test('it generates a detail report with fewer vulns when a severity threshold higher than some vulns is set', function (t) {
+  return Report(fixtures['all-severity-vulns'], {reporter: 'detail', severityThreshold: 'high', withColor: false}).then((report) => {
+    t.equal(report.exitCode, 1, 'non-zero exit code')
+    t.match(report.report, /found 3 vulnerabilities/, 'reports vuln count')
+    t.match(report.report, /2 high, 1 critical/, 'severity breakdown reported')
+  })
+})
+
+tap.test('it generates a detail report with no vulns when a severity threshold higher than all vulns is set', function (t) {
+  return Report(fixtures['some-vulns'], {reporter: 'detail', severityThreshold: 'critical', withColor: false}).then((report) => {
+    t.match(report.exitCode, 0, 'successful exit code')
+    t.match(report.report, /found 0 vulnerabilities/, 'no vulns reported')
+    t.match(report.report, /918 scanned packages/, 'reports scanned count')
+  })
+})

--- a/test/detail-report-test.js
+++ b/test/detail-report-test.js
@@ -100,3 +100,11 @@ tap.test('it generates a detail report with review vulns, no unicode', function 
     t.match(report.report, /1 low, 1 moderate, 1 critical/, 'severity breakdown reported')
   })
 })
+
+tap.test('it generates a detail report with no vulns when a dev dep has a vuln and dev deps are excluded', function (t) {
+  return Report(fixtures['one-vuln-dev'], {reporter: 'detail', excludeDev: true, withColor: false}).then((report) => {
+    t.equal(report.exitCode, 0, 'successful exit code')
+    t.match(report.report, /found 0 vulnerabilities/, 'no vulns reported')
+    t.match(report.report, /918 scanned packages/, 'reports scanned count')
+  })
+})

--- a/test/fixtures/all-severity-vulns.json
+++ b/test/fixtures/all-severity-vulns.json
@@ -28,6 +28,18 @@
         },
         {
           "id": 534,
+          "path": "standard>eslint>debug",
+          "dev": true,
+          "optional": false
+        },
+        {
+          "id": 534,
+          "path": "standard>eslint>debug",
+          "dev": true,
+          "optional": false
+        },
+        {
+          "id": 534,
           "path": "standard>eslint-plugin-import>debug",
           "dev": true,
           "optional": false
@@ -73,6 +85,114 @@
       "target": "4.2.1",
       "resolves": [
         {
+          "id": 1,
+          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
+          "dev": true,
+          "optional": false
+        },
+        {
+          "id": 1,
+          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
+          "dev": true,
+          "optional": false
+        },
+        {
+          "id": 1,
+          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
+          "dev": true,
+          "optional": false
+        },
+        {
+          "id": 1,
+          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
+          "dev": true,
+          "optional": false
+        },
+        {
+          "id": 1,
+          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
+          "dev": true,
+          "optional": false
+        },
+        {
+          "id": 1,
+          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
+          "dev": true,
+          "optional": false
+        },
+        {
+          "id": 1,
+          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
+          "dev": true,
+          "optional": false
+        },
+        {
+          "id": 1,
+          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
+          "dev": true,
+          "optional": false
+        },
+        {
+          "id": 1,
+          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
+          "dev": true,
+          "optional": false
+        },
+        {
+          "id": 1,
+          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
+          "dev": true,
+          "optional": false
+        },
+        {
+          "id": 1,
+          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
+          "dev": true,
+          "optional": false
+        },
+        {
+          "id": 1,
+          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
+          "dev": true,
+          "optional": false
+        },
+        {
+          "id": 1,
+          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
+          "dev": true,
+          "optional": false
+        },
+        {
+          "id": 1,
+          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
+          "dev": true,
+          "optional": false
+        },
+        {
+          "id": 1,
+          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
+          "dev": true,
+          "optional": false
+        },
+        {
+          "id": 1,
+          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
+          "dev": true,
+          "optional": false
+        },
+        {
+          "id": 157,
+          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
+          "dev": true,
+          "optional": false
+        },
+        {
+          "id": 157,
+          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
+          "dev": true,
+          "optional": false
+        },
+        {
           "id": 157,
           "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
           "dev": true,
@@ -112,6 +232,55 @@
     }
   ],
   "advisories": {
+    "1": {
+      "findings": [
+        {
+          "version": "1.1.7",
+          "paths": [
+            "tap>nyc>micromatch>braces>expand-range>fill-range>randomatic",
+            "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic"
+          ],
+          "dev": true,
+          "optional": false
+        },
+        {
+          "version": "1.1.7",
+          "paths": [
+            "@npm/spife>chokidar>anymatch>micromatch>braces>expand-range>fill-range>randomatic"
+          ],
+          "dev": false,
+          "optional": false
+        }
+      ],
+      "id": 1,
+      "created": "2016-11-09T20:03:19.000Z",
+      "updated": "2018-03-02T23:21:42.009Z",
+      "deleted": null,
+      "title": "Cryptographically Weak PRNG",
+      "found_by": {
+        "name": "Sven Slootweg"
+      },
+      "reported_by": {
+        "name": "Sven Slootweg"
+      },
+      "module_name": "randomatic",
+      "cves": [
+        "CVE-2017-16028"
+      ],
+      "vulnerable_versions": "<3.0.0",
+      "patched_versions": ">=3.0.0",
+      "overview": "Affected versions of `randomatic` generate random values using a cryptographically weak psuedo-random number generator. This may result in predictable values instead of random values as intended.\r\n\r\n",
+      "recommendation": "Update to version 3.0.0 or later.\r\n",
+      "references": "[Commit #4a52695](https://github.com/jonschlinkert/randomatic/commit/4a526959b3a246ae8e4a82f9c182180907227fe1#diff-b9cfc7f2cdf78a7f4b91a753d10865a2)",
+      "access": "public",
+      "severity": "info",
+      "cwe": "CWE-330",
+      "metadata": {
+        "module_type": "Multi.Library",
+        "exploitability": 5,
+        "affected_components": ""
+      }
+    },
     "157": {
       "findings": [
         {
@@ -153,7 +322,7 @@
       "recommendation": "Update to version 3.0.0 or later.\r\n",
       "references": "[Commit #4a52695](https://github.com/jonschlinkert/randomatic/commit/4a526959b3a246ae8e4a82f9c182180907227fe1#diff-b9cfc7f2cdf78a7f4b91a753d10865a2)",
       "access": "public",
-      "severity": "low",
+      "severity": "moderate",
       "cwe": "CWE-330",
       "metadata": {
         "module_type": "Multi.Library",
@@ -193,7 +362,7 @@
       "recommendation": "Please update to version 2.3.3 or greater",
       "references": "- https://github.com/salesforce/tough-cookie/issues/92",
       "access": "public",
-      "severity": "high",
+      "severity": "critical",
       "cwe": "CWE-400",
       "metadata": {
         "module_type": "",

--- a/test/fixtures/some-vulns.json
+++ b/test/fixtures/some-vulns.json
@@ -28,6 +28,12 @@
         },
         {
           "id": 534,
+          "path": "standard>eslint>debug",
+          "dev": true,
+          "optional": false
+        },
+        {
+          "id": 534,
           "path": "standard>eslint-plugin-import>debug",
           "dev": true,
           "optional": false

--- a/test/install-report-test.js
+++ b/test/install-report-test.js
@@ -7,35 +7,35 @@ const fixtures = require('./lib/test-fixtures')
 tap.test('it generates an install report with no vulns', function (t) {
   return Report(fixtures['no-vulns']).then((report) => {
     t.match(report.report, /found .*0.* vulnerabilities/)
-    t.match(report.exitCode, 0)
+    t.equal(report.exitCode, 0)
   })
 })
 
 tap.test('it generates an install report with no vulns, no colors', function (t) {
   return Report(fixtures['no-vulns'], {withColor: false}).then((report) => {
     t.match(report.report, /found 0 vulnerabilities/)
-    t.match(report.exitCode, 0)
+    t.equal(report.exitCode, 0)
   })
 })
 
 tap.test('it generates an install report with one vuln', function (t) {
   return Report(fixtures['one-vuln'], {withColor: false}).then((report) => {
     t.match(report.report, /found 1 high severity vulnerability/)
-    t.match(report.exitCode, 1)
+    t.equal(report.exitCode, 1)
   })
 })
 
 tap.test('recommend `npm audit fix` when install actions present', t => {
   return Report(fixtures['one-vuln'], {withColor: false}).then((report) => {
     t.match(report.report, /run `npm audit fix`/)
-    t.match(report.exitCode, 1)
+    t.equal(report.exitCode, 1)
   })
 })
 
 tap.test('it generates an install report with multiple vulns of one type', function (t) {
   return Report(fixtures['some-same-type'], {withColor: false}).then((report) => {
     t.match(report.report, /found 12 high severity vulnerabilities/)
-    t.match(report.exitCode, 1)
+    t.equal(report.exitCode, 1)
   })
 })
 
@@ -43,7 +43,7 @@ tap.test('it generates an install report with more than one vuln', function (t) 
   return Report(fixtures['some-vulns']).then((report) => {
     t.match(report.report, /^found .*12.* vulnerabilities/)
     t.match(report.report, /9 .*low.*, 3 .*high.*/)
-    t.match(report.exitCode, 1)
+    t.equal(report.exitCode, 1)
   })
 })
 
@@ -51,6 +51,6 @@ tap.test('it generates an install report with vulns of all severities', function
   return Report(fixtures['all-severity-vulns']).then((report) => {
     t.match(report.report, /^found .*31.* vulnerabilities/)
     t.match(report.report, /16 .*info, 8 .*low.*, 4 .*moderate.*, 2 .*high.*, 1 .*critical.*/)
-    t.match(report.exitCode, 1)
+    t.equal(report.exitCode, 1)
   })
 })

--- a/test/parseable-report-test.js
+++ b/test/parseable-report-test.js
@@ -6,21 +6,21 @@ const Keyfob = require('keyfob')
 
 const fixtures = Keyfob.load({ path: 'test/fixtures', fn: require })
 
-tap.test('it generates a detail report with no vulns', function (t) {
+tap.test('it generates a parseable report with no vulns', function (t) {
   return Report(fixtures['no-vulns'], {reporter: 'parseable'}).then((report) => {
-    t.match(report.exitCode, 0, 'successful exit code')
+    t.equal(report.exitCode, 0, 'successful exit code')
     t.equal(report.report.length, 0, 'no vulns reported')
   })
 })
 
-tap.test('it generates a detail report with one vuln (update action)', function (t) {
+tap.test('it generates a parseable report with one vuln (update action)', function (t) {
   return Report(fixtures['one-vuln-one-pkg'], {reporter: 'parseable'}).then((report) => {
     t.equal(report.exitCode, 1, 'non-zero exit code')
     t.match(report.report, /\tnpm update tough-cookie --depth 6/, 'recommends update command with --depth')
   })
 })
 
-tap.test('it generates a detail report with one vuln (update action)', function (t) {
+tap.test('it generates a parseable report with one vuln (update action)', function (t) {
   return Report(fixtures['one-vuln'], {reporter: 'parseable'}).then((report) => {
     t.equal(report.exitCode, 1, 'non-zero exit code')
     t.match(report.report, /^update/)
@@ -28,7 +28,7 @@ tap.test('it generates a detail report with one vuln (update action)', function 
   })
 })
 
-tap.test('it generates a detail report with one vuln (install action)', function (t) {
+tap.test('it generates a parseable report with one vuln (install action)', function (t) {
   return Report(fixtures['one-vuln-install'], {reporter: 'parseable'}).then((report) => {
     t.equal(report.exitCode, 1, 'non-zero exit code')
     t.match(report.report, /^install/)
@@ -50,14 +50,14 @@ tap.test('it adds a message if a dep isMajor (multiple vulns)', function (t) {
   })
 })
 
-tap.test('it generates a detail report with one vuln (install dev dep)', function (t) {
+tap.test('it generates a parseable report with one vuln (install dev dep)', function (t) {
   return Report(fixtures['one-vuln-dev'], {reporter: 'parseable'}).then((report) => {
     t.equal(report.exitCode, 1, 'non-zero exit code')
     t.match(report.report, /npm install --save-dev knex@3.0.0/)
   })
 })
 
-tap.test('it generates a detail report with one vuln (review dev dep)', function (t) {
+tap.test('it generates a parseable report with one vuln (review dev dep)', function (t) {
   return Report(fixtures['one-vuln-dev-review'], {reporter: 'parseable'}).then((report) => {
     t.equal(report.exitCode, 1, 'non-zero exit code')
     t.match(report.report, /review\t/, 'expects manual review')
@@ -65,7 +65,7 @@ tap.test('it generates a detail report with one vuln (review dev dep)', function
   })
 })
 
-tap.test('it generates a detail report with some vulns', function (t) {
+tap.test('it generates a parseable report with some vulns', function (t) {
   return Report(fixtures['some-vulns'], {reporter: 'parseable'}).then((report) => {
     t.equal(report.exitCode, 1, 'non-zero exit code')
     t.match(report.report, /review\t/, 'expects manual review')
@@ -76,7 +76,7 @@ tap.test('it generates a detail report with some vulns', function (t) {
   })
 })
 
-tap.test('it generates a detail report with review vulns', function (t) {
+tap.test('it generates a parseable report with review vulns', function (t) {
   return Report(fixtures['update-review'], {reporter: 'parseable'}).then((report) => {
     t.equal(report.exitCode, 1, 'non-zero exit code')
     t.match(report.report, /review\t/, 'expects manual review')

--- a/test/parseable-report-test.js
+++ b/test/parseable-report-test.js
@@ -89,3 +89,18 @@ tap.test('it generates a parseable report with no vulns when a dev dep has a vul
     t.equal(report.report.length, 0, 'no vulns reported')
   })
 })
+
+tap.test('it generates a parseable report with fewer vulns when a higher severity threshold is set', function (t) {
+  return Report(fixtures['all-severity-vulns'], {reporter: 'parseable', severityThreshold: 'high'}).then((report) => {
+    t.equal(report.exitCode, 1, 'non-zero exit code')
+    t.match(report.report, /\thigh/)
+    t.match(report.report, /\tDenial of Service/)
+  })
+})
+
+tap.test('it generates a parseable report with no vulns when a severity threshold higher than all vulns is set', function (t) {
+  return Report(fixtures['some-vulns'], {reporter: 'parseable', severityThreshold: 'critical'}).then((report) => {
+    t.equal(report.exitCode, 0, 'successful exit code')
+    t.equal(report.report.length, 0, 'no vulns reported')
+  })
+})

--- a/test/parseable-report-test.js
+++ b/test/parseable-report-test.js
@@ -82,3 +82,10 @@ tap.test('it generates a parseable report with review vulns', function (t) {
     t.match(report.report, /review\t/, 'expects manual review')
   })
 })
+
+tap.test('it generates a parseable report with no vulns when a dev dep has a vuln and dev deps are excluded', function (t) {
+  return Report(fixtures['one-vuln-dev'], {reporter: 'parseable', excludeDev: true}).then((report) => {
+    t.equal(report.exitCode, 0, 'successful exit code')
+    t.equal(report.report.length, 0, 'no vulns reported')
+  })
+})

--- a/test/quiet-report-test.js
+++ b/test/quiet-report-test.js
@@ -6,13 +6,13 @@ const fixtures = require('./lib/test-fixtures')
 
 tap.test('it generates an quiet report with no vulns', function (t) {
   return Report(fixtures['no-vulns'], {reporter: 'quiet'}).then((report) => {
-    t.match(report.report, '')
-    t.match(report.exitCode, 0)
+    t.equal(report.report, '')
+    t.equal(report.exitCode, 0)
   })
 })
 tap.test('it generates an quiet report with one vuln', function (t) {
   return Report(fixtures['one-vuln'], {reporter: 'quiet'}).then((report) => {
-    t.match(report.report, '')
-    t.match(report.exitCode, 1)
+    t.equal(report.report, '')
+    t.equal(report.exitCode, 1)
   })
 })

--- a/test/quiet-report-test.js
+++ b/test/quiet-report-test.js
@@ -24,3 +24,17 @@ tap.test('it generates a quiet report with no vulns when a dev dep has a vuln an
     t.match(report.exitCode, 0)
   })
 })
+
+tap.test('it generates a quiet report with fewer vulns when a higher severity threshold is set', function (t) {
+  return Report(fixtures['all-severity-vulns'], {reporter: 'quiet', severityThreshold: 'high'}).then((report) => {
+    t.equal(report.report, '')
+    t.equal(report.exitCode, 1)
+  })
+})
+
+tap.test('it generates a quiet report with no vulns when a severity threshold higher than all vulns is set', function (t) {
+  return Report(fixtures['some-vulns'], {reporter: 'quiet', severityThreshold: 'critical'}).then((report) => {
+    t.equal(report.report, '')
+    t.equal(report.exitCode, 0)
+  })
+})

--- a/test/quiet-report-test.js
+++ b/test/quiet-report-test.js
@@ -10,9 +10,17 @@ tap.test('it generates an quiet report with no vulns', function (t) {
     t.equal(report.exitCode, 0)
   })
 })
+
 tap.test('it generates an quiet report with one vuln', function (t) {
   return Report(fixtures['one-vuln'], {reporter: 'quiet'}).then((report) => {
     t.equal(report.report, '')
     t.equal(report.exitCode, 1)
+  })
+})
+
+tap.test('it generates a quiet report with no vulns when a dev dep has a vuln and dev deps are excluded', function (t) {
+  return Report(fixtures['one-vuln-dev'], {reporter: 'quiet', excludeDev: true}).then((report) => {
+    t.match(report.report, '')
+    t.match(report.exitCode, 0)
   })
 })

--- a/test/reporters-test.js
+++ b/test/reporters-test.js
@@ -3,24 +3,25 @@
 const tap = require('tap')
 const Report = require('../')
 const Keyfob = require('keyfob')
-const {totalVulnCount, severities} = require('../lib/utils')
 const fixtures = Keyfob.load({path: 'test/fixtures', fn: require})
+
+const {vulnTotal, severities} = require('../lib/utils')
 
 tap.test('total vuln count is 0 with no vulns', function (t) {
   return Report(fixtures['no-vulns'], {reporter: 'json'}).then((reportRaw) => {
-    t.equal(totalVulnCount(JSON.parse(reportRaw.report).metadata.vulnerabilities), 0)
+    t.equal(vulnTotal(JSON.parse(reportRaw.report).metadata.vulnerabilities), 0)
   })
 })
 
 tap.test('total vuln count is calculated with some vulns', function (t) {
   return Report(fixtures['some-vulns'], {reporter: 'json'}).then((reportRaw) => {
-    t.equal(totalVulnCount(JSON.parse(reportRaw.report).metadata.vulnerabilities), 12)
+    t.equal(vulnTotal(JSON.parse(reportRaw.report).metadata.vulnerabilities), 12)
   })
 })
 
 tap.test('total vuln count is calculated with all severity vulns', function (t) {
   return Report(fixtures['all-severity-vulns'], {reporter: 'json'}).then((reportRaw) => {
-    t.equal(totalVulnCount(JSON.parse(reportRaw.report).metadata.vulnerabilities), 31)
+    t.equal(vulnTotal(JSON.parse(reportRaw.report).metadata.vulnerabilities), 31)
   })
 })
 

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const tap = require('tap')
-const {severityLabel, color} = require('../lib/utils')
+const {color, severityLabel, severityCompare} = require('../lib/utils')
 
 tap.test('color does just return the value if colorName AND withColor are missing', function (t) {
   t.equal(color('Low'), 'Low')
@@ -17,19 +17,73 @@ tap.test('color returns a formatted string if all params are set', function (t) 
   t.done()
 })
 
-tap.test('severity does not throw an error if given severity is not defined', function (t) {
+tap.test('severityLabel does not throw an error if given severity is not defined', function (t) {
   t.doesNotThrow(function () { severityLabel('me-no-exist') })
   t.done()
 })
 
-tap.test('severity returns a label if there is no color mapping', function (t) {
+tap.test('severityLabel returns a label if there is no color mapping', function (t) {
   t.equal(severityLabel('me-no-exist'), 'Me-no-exist')
   t.equal(severityLabel('w000000t'), 'W000000t')
   t.done()
 })
 
-tap.test('severity returns a label with color formatting ', function (t) {
+tap.test('severityLabel returns a label with color formatting ', function (t) {
   t.equal(severityLabel('high', true, true), '\u001b[91;1mHigh\u001b[0m')
   t.equal(severityLabel('low', true, true), '\u001b[1;1mLow\u001b[0m')
+  t.done()
+})
+
+tap.test('severityCompare does not throw an error if given severity is not defined', function (t) {
+  t.doesNotThrow(function () { severityCompare('low', 'me-no-exist') })
+  t.doesNotThrow(function () { severityCompare('me-no-exist', 'low') })
+  t.done()
+})
+
+tap.test('severityCompare returns 0 when comparing the same severity', function (t) {
+  t.equal(severityCompare('critical', 'critical'), 0)
+  t.equal(severityCompare('high', 'high'), 0)
+  t.equal(severityCompare('moderate', 'moderate'), 0)
+  t.equal(severityCompare('low', 'low'), 0)
+  t.equal(severityCompare('info', 'info'), 0)
+  t.equal(severityCompare('me-no-exist', 'me-no-exist'), 0)
+  t.done()
+})
+
+tap.test('severityCompare returns <0 only when first severity is more severe than 2nd severity', function (t) {
+  t.ok(severityCompare('me-no-exist', 'critical') < 0)
+  t.ok(severityCompare('me-no-exist', 'high') < 0)
+  t.ok(severityCompare('me-no-exist', 'moderate') < 0)
+  t.ok(severityCompare('me-no-exist', 'low') < 0)
+  t.ok(severityCompare('me-no-exist', 'info') < 0)
+  t.ok(severityCompare('critical', 'high') < 0)
+  t.ok(severityCompare('critical', 'moderate') < 0)
+  t.ok(severityCompare('critical', 'low') < 0)
+  t.ok(severityCompare('critical', 'info') < 0)
+  t.ok(severityCompare('high', 'moderate') < 0)
+  t.ok(severityCompare('high', 'low') < 0)
+  t.ok(severityCompare('high', 'info') < 0)
+  t.ok(severityCompare('moderate', 'low') < 0)
+  t.ok(severityCompare('moderate', 'info') < 0)
+  t.ok(severityCompare('low', 'info') < 0)
+  t.done()
+})
+
+tap.test('severityCompare returns >0 only when first severity is less severe than 2nd severity', function (t) {
+  t.ok(severityCompare('info', 'low') > 0)
+  t.ok(severityCompare('info', 'moderate') > 0)
+  t.ok(severityCompare('info', 'high') > 0)
+  t.ok(severityCompare('info', 'critical') > 0)
+  t.ok(severityCompare('info', 'me-no-exist') > 0)
+  t.ok(severityCompare('low', 'moderate') > 0)
+  t.ok(severityCompare('low', 'high') > 0)
+  t.ok(severityCompare('low', 'critical') > 0)
+  t.ok(severityCompare('low', 'me-no-exist') > 0)
+  t.ok(severityCompare('moderate', 'high') > 0)
+  t.ok(severityCompare('moderate', 'critical') > 0)
+  t.ok(severityCompare('moderate', 'me-no-exist') > 0)
+  t.ok(severityCompare('high', 'critical') > 0)
+  t.ok(severityCompare('high', 'me-no-exist') > 0)
+  t.ok(severityCompare('critical', 'me-no-exist') > 0)
   t.done()
 })


### PR DESCRIPTION
This PR is my attempt to implement filtering of reported vulnerabilities based on various configurable parameters. I realise this is fairly sizeable and I might be touching too much, so please feel free to suggest areas that could be split into independent PRs, simplified, improved, done differently, squashed, etc.

Currently this implements #13 and npm/npm#20564.
I'd also like to implement npm/npm#20565 (making full use of things like paths, not just the advisory ID), but I'm looking for input from others on which information will be stored in package.json and its structure.
Once the dust has settled here, I'll send a complementary PR to the cli repo for the changes needed there.