### PR TITLE
Prevent conversion of undefined/null to object, replace with warning

### DIFF
--- a/reporters/install.js
+++ b/reporters/install.js
@@ -40,7 +40,7 @@ function summary (data, options) {
   }
 
   if (!data.advisories) {
-    log(`${yellow('WARN')}: There was an error contacting the audit server`);
+    log(`${yellow('WARN')}: There was an error contacting the audit server`)
   }
 
   output += 'found '

--- a/reporters/install.js
+++ b/reporters/install.js
@@ -5,7 +5,8 @@ const Utils = require('../lib/utils')
 module.exports = report
 function report (data, options) {
   let msg = summary(data, options)
-  if (!Object.keys(data.advisories).length) {
+
+  if (!Object.keys(data.advisories || {}).length) {
     return {
       report: msg,
       exitCode: 0
@@ -29,6 +30,7 @@ function summary (data, options) {
 
   function clr (str, clr) { return Utils.color(str, clr, config.withColor) }
   function green (str) { return clr(str, 'brightGreen') }
+  function yellow (str) { return clr(str, 'brightYellow') }
   function red (str) { return clr(str, 'brightRed') }
 
   let output = ''
@@ -37,9 +39,13 @@ function summary (data, options) {
     output = output + value + '\n'
   }
 
+  if (!data.advisories) {
+    log(`${yellow('WARN')}: There was an error contacting the audit server`);
+  }
+
   output += 'found '
 
-  if (Object.keys(data.advisories).length === 0) {
+  if (Object.keys(data.advisories || {}).length === 0) {
     log(`${green('0')} vulnerabilities`)
     return output
   } else {

--- a/test/fixtures/missing-advisories-no-vulns.json
+++ b/test/fixtures/missing-advisories-no-vulns.json
@@ -1,0 +1,17 @@
+{
+  "actions": [],
+  "muted": [],
+  "metadata":{
+    "dependencies": 375,
+    "devDependencies": 466,
+    "optionalDependencies": 77,
+    "totalDependencies": 918,
+    "vulnerabilities": {
+      "info": 0,
+      "low": 0,
+      "moderate": 0,
+      "high": 0,
+      "critical": 0
+    }
+  }    
+}

--- a/test/install-report-test.js
+++ b/test/install-report-test.js
@@ -54,3 +54,11 @@ tap.test('it generates an install report with vulns of all severities', function
     t.match(report.exitCode, 1)
   })
 })
+
+tap.test('it generates an install report a warning if advisories are not set', function (t) {
+  return Report(fixtures['missing-advisories-no-vulns'], {advisories: null}).then((report) => {
+    t.match(report.report, /.*WARN.* There was an error contacting the audit server/)
+    t.match(report.report, /found .*0.* vulnerabilities/)
+    t.match(report.exitCode, 0)
+  })
+})


### PR DESCRIPTION
npm-audit-report is erroring with:

`npm ERR! Cannot convert undefined or null to object`

when advisories is not defined in the data object in `install.js`

Rather than throwing a javascript error, this PR adds a yellow-level log warning letting users know there was an error contacting the audit server.