### PR TITLE
Replace hardcoded URL to advisory with a URL from audit response

### DIFF
--- a/reporters/detail.js
+++ b/reporters/detail.js
@@ -117,7 +117,7 @@ const report = function (data, options) {
               {'Package': advisory.module_name},
               {'Dependency of': `${resolution.path.split('>')[0]} ${resolution.dev ? '[dev]' : ''}`},
               {'Path': `${resolution.path.split('>').join(Utils.color(' > ', 'grey', config.withColor))}`},
-              {'More info': `https://nodesecurity.io/advisories/${advisory.id}`}
+              {'More info': advisory.url || `https://www.npmjs.com/advisories/${advisory.id}`}
             )
 
             log(table.toString() + '\n\n')
@@ -160,7 +160,7 @@ const report = function (data, options) {
               {'Patched in': patchedIn},
               {'Dependency of': `${resolution.path.split('>')[0]} ${resolution.dev ? '[dev]' : ''}`},
               {'Path': `${resolution.path.split('>').join(Utils.color(' > ', 'grey', config.withColor))}`},
-              {'More info': `https://nodesecurity.io/advisories/${advisory.id}`}
+              {'More info': advisory.url || `https://www.npmjs.com/advisories/${advisory.id}`}
             )
             log(table.toString())
           })

--- a/reporters/parseable.js
+++ b/reporters/parseable.js
@@ -32,7 +32,7 @@ const report = function (data, options) {
             l.sevLevel = advisory.severity
             l.severity = advisory.title
             l.package = advisory.module_name
-            l.moreInfo = `https://nodesecurity.io/advisories/${advisory.id}`
+            l.moreInfo = advisory.url || `https://www.npmjs.com/advisories/${advisory.id}`
             l.path = resolution.path
 
             accumulator[advisory.severity] += [action.action, l.package, l.sevLevel, l.recommendation, l.severity, l.moreInfo, l.path, l.breaking]
@@ -47,7 +47,7 @@ const report = function (data, options) {
             l.sevLevel = advisory.severity
             l.severity = advisory.title
             l.package = advisory.module_name
-            l.moreInfo = `https://nodesecurity.io/advisories/${advisory.id}`
+            l.moreInfo = advisory.url || `https://www.npmjs.com/advisories/${advisory.id}`
             l.patchedIn = advisory.patched_versions.replace(' ', '') === '<0.0.0' ? 'No patch available' : advisory.patched_versions
             l.path = resolution.path
 

--- a/test/fixtures/some-same-action.json
+++ b/test/fixtures/some-same-action.json
@@ -64,7 +64,7 @@
         "exploitability": 5,
         "affected_components": ""
       },
-      "url": "https://nodesecurity.io/advisories/146"
+      "url": "https://www.npmjs.com/advisories/146"
     },
     "534": {
       "findings": [
@@ -106,7 +106,7 @@
         "exploitability": 5,
         "affected_components": ""
       },
-      "url": "https://nodesecurity.io/advisories/534"
+      "url": "https://www.npmjs.com/advisories/534"
     }
   },
   "muted": [],

--- a/test/fixtures/some-vulns-critical.json
+++ b/test/fixtures/some-vulns-critical.json
@@ -57,7 +57,7 @@
         "exploitability": 5,
         "affected_components": ""
       },
-      "url": "https://nodesecurity.io/advisories/146"
+      "url": "https://www.npmjs.com/advisories/146"
     }
   },
   "muted": [],


### PR DESCRIPTION
By this PR, we can see a correct advisory URL in the "More info" field.