### PR TITLE
provide severity option

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,13 +1,8 @@
 'use strict'
 
-exports.severityLabel = severityLabel
-exports.color = color
-exports.totalVulnCount = totalVulnCount
-exports.severities = severities
-
 const ccs = require('console-control-strings')
 
-const severityColors = {
+const severityMetadata = {
   critical: {
     color: 'brightMagenta',
     label: 'Critical'
@@ -29,32 +24,116 @@ const severityColors = {
     label: 'Info'
   }
 }
+const severityOrder = ['critical', 'high', 'moderate', 'low', 'info']
+severityOrder.forEach((severity, order) => {
+  severityMetadata[severity].order = order
+})
 
-function color (value, colorName, withColor) {
+const color = exports.color = function (value, colorName, withColor) {
   return (colorName && withColor) ? ccs.color(colorName) + value + ccs.color('reset') : value
 }
 
-function severityLabel (sev, withColor, bold) {
-  if (!(sev in severityColors)) return sev.charAt(0).toUpperCase() + sev.substr(1).toLowerCase()
-  let colorName = severityColors[sev].color
+const severityLabel = exports.severityLabel = function (sev, withColor, bold) {
+  if (!(sev in severityMetadata)) return sev.charAt(0).toUpperCase() + sev.substr(1).toLowerCase()
+  let colorName = severityMetadata[sev].color
   if (bold) colorName = [colorName, 'bold']
-  return color(severityColors[sev].label, colorName, withColor)
+  return color(severityMetadata[sev].label, colorName, withColor)
 }
 
-function totalVulnCount (vulns) {
-  return Object.keys(vulns).reduce((accumulator, key) => {
-    const vulnCount = vulns[key]
+const severityCompare = exports.severityCompare = function (a, b) {
+  a = a.severity || a
+  b = b.severity || b
+  const oA = a in severityMetadata ? severityMetadata[a].order : -1
+  const oB = b in severityMetadata ? severityMetadata[b].order : -1
+  return oA - oB
+}
+
+exports.vulnTotal = function (vulns) {
+  return Object.keys(vulns).reduce((accumulator, severity) => {
+    const vulnCount = vulns[severity]
     accumulator += vulnCount
 
     return accumulator
   }, 0)
 }
 
-function severities (vulns) {
+exports.vulnSummary = function (vulns, config) {
+  config = Object.assign({
+    excludeDev: false,
+    excludeProd: false,
+    severityThreshold: 'info'
+  }, config)
+  const summary = {
+    total: 0
+  }
+
+  const sev = Object.keys(vulns).reduce((accumulator, severity) => {
+    const excludeSeverity = severityCompare(config.severityThreshold, severity) < 0
+
+    if (!excludeSeverity) {
+      const vulnCount = vulns[severity]
+      if (vulnCount > 0) {
+        summary.total += vulnCount
+        accumulator.push(`${vulnCount} ${severityLabel(severity, config.withColor).toLowerCase()}`)
+      }
+    }
+
+    return accumulator
+  }, [])
+
+  if (summary.total === 0) {
+    summary.msg = `found ${color('0', 'brightGreen', config.withColor)} vulnerabilities`
+  } else if (sev.length === 1) {
+    summary.msg = `found ${sev[0]} severity vulnerabilit${summary.total === 1 ? 'y' : 'ies'}`
+  } else {
+    summary.msg = `found ${color(summary.total, 'brightRed', config.withColor)} vulnerabilities (${sev.join(', ')})`
+  }
+
+  return summary
+}
+
+exports.vulnFilter = function (data, config) {
+  config = Object.assign({
+    excludeDev: false,
+    excludeProd: false,
+    severityThreshold: 'info'
+  }, config)
+  data.actions.forEach((action) => {
+    action.resolves = action.resolves.filter(({id, dev}) => {
+      const severity = data.advisories[id].severity
+      const excludeSeverity = severityCompare(config.severityThreshold, severity) < 0
+      const exclude = config[dev ? 'excludeDev' : 'excludeProd'] || excludeSeverity
+      if (exclude) {
+        data.metadata.vulnerabilities[severity]--
+        data.metadata.excluded = data.metadata.excluded || {}
+        data.metadata.excluded[severity] = (data.metadata.excluded[severity] || 0) + 1
+      }
+      return !exclude
+    })
+  })
+}
+
+exports.severities = function (vulns) {
   return Object.keys(vulns).reduce((accumulator, severity) => {
     const vulnCount = vulns[severity]
     if (vulnCount > 0) accumulator.push([severity, vulnCount])
 
     return accumulator
   }, [])
+}
+
+exports.getRecommendation = function (action, config) {
+  if (action.action === 'install') {
+    const isDev = action.resolves[0].dev
+
+    return {
+      cmd: `npm install ${isDev ? '--save-dev ' : ''}${action.module}@${action.target}`,
+      isBreaking: action.isMajor
+    }
+  } else {
+    return {
+      cmd: `npm update ${action.module} --depth ${action.depth}`,
+      isBreaking: false
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-audit-report",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -60,6 +60,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -1043,12 +1044,18 @@
       "dev": true
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dev": true,
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
       }
     },
     "debug-log": {
@@ -1286,10 +1293,25 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
         "lodash": {
           "version": "4.17.10",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
           "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         },
         "strip-ansi": {
@@ -2196,7 +2218,8 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -2455,6 +2478,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
@@ -2556,7 +2580,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -2873,6 +2898,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -4055,7 +4081,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",
@@ -5893,7 +5920,8 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "repeating": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-audit-report",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Given a response from the npm security api, render it into a variety of security reports",
   "main": "index.js",
   "scripts": {

--- a/reporters/install.js
+++ b/reporters/install.js
@@ -43,7 +43,7 @@ function summary (data, options) {
     log(`${green('0')} vulnerabilities`)
     return output
   } else {
-    const total = Utils.totalVulnCount(data.metadata.vulnerabilities)
+    const total = Utils.vulnTotal(data.metadata.vulnerabilities)
     const sev = Utils.severities(data.metadata.vulnerabilities)
 
     if (sev.length > 1) {

--- a/reporters/parseable.js
+++ b/reporters/parseable.js
@@ -1,13 +1,14 @@
 'use strict'
 
+const Utils = require('../lib/utils')
+
 const report = function (data, options) {
-  const defaults = {
-    severityThreshold: 'info'
-  }
+  const defaults = {}
 
   const config = Object.assign({}, defaults, options)
 
-  let exit = 0
+  Utils.vulnFilter(data, config)
+  const vulnTotal = Utils.vulnTotal(data.metadata.vulnerabilities)
 
   const actions = function (data, config) {
     let accumulator = {
@@ -17,82 +18,47 @@ const report = function (data, options) {
       low: ''
     }
 
-    if (Object.keys(data.advisories).length !== 0) {
-      data.actions.forEach((action) => {
-        let l = {}
-        // Start with install/update actions
-        if (action.action === 'update' || action.action === 'install') {
-          const recommendation = getRecommendation(action, config)
-          l.recommendation = recommendation.cmd
-          l.breaking = recommendation.isBreaking ? 'Y' : 'N'
+    data.actions.forEach(action => {
+      const recommendation =
+        action.action === 'update' || action.action === 'install'
+          ? Utils.getRecommendation(action, config)
+          : null
+      if (recommendation) {
+        recommendation.breaking = recommendation.isBreaking ? 'Y' : 'N'
+      }
 
-          action.resolves.forEach((resolution) => {
-            const advisory = data.advisories[resolution.id]
+      action.resolves.forEach(resolution => {
+        const advisory = data.advisories[resolution.id]
 
-            l.sevLevel = advisory.severity
-            l.severity = advisory.title
-            l.package = advisory.module_name
-            l.moreInfo = advisory.url || `https://www.npmjs.com/advisories/${advisory.id}`
-            l.path = resolution.path
+        const line = [action.action, advisory.module_name, advisory.severity]
 
-            accumulator[advisory.severity] += [action.action, l.package, l.sevLevel, l.recommendation, l.severity, l.moreInfo, l.path, l.breaking]
-              .join('\t') + '\n'
-          }) // forEach resolves
+        if (recommendation) {
+          line.push(recommendation.cmd)
+        } else {
+          line.push(
+            advisory.patched_versions.replace(' ', '') === '<0.0.0'
+              ? 'No patch available'
+              : advisory.patched_versions
+          )
+        }
+        line.push(
+          advisory.title,
+          'https://nodesecurity.io/advisories/' + advisory.id,
+          resolution.path
+        )
+        if (recommendation) {
+          line.push(recommendation.breaking)
         }
 
-        if (action.action === 'review') {
-          action.resolves.forEach((resolution) => {
-            const advisory = data.advisories[resolution.id]
-
-            l.sevLevel = advisory.severity
-            l.severity = advisory.title
-            l.package = advisory.module_name
-            l.moreInfo = advisory.url || `https://www.npmjs.com/advisories/${advisory.id}`
-            l.patchedIn = advisory.patched_versions.replace(' ', '') === '<0.0.0' ? 'No patch available' : advisory.patched_versions
-            l.path = resolution.path
-
-            accumulator[advisory.severity] += [action.action, l.package, l.sevLevel, l.patchedIn, l.severity, l.moreInfo, l.path].join('\t') + '\n'
-          }) // forEach resolves
-        } // is review
-      }) // forEach actions
-    }
+        accumulator[advisory.severity] += line.join('\t') + '\n'
+      })
+    })
     return accumulator['critical'] + accumulator['high'] + accumulator['moderate'] + accumulator['low']
   }
 
-  const exitCode = function (metadata) {
-    let total = 0
-    const keys = Object.keys(metadata.vulnerabilities)
-    for (let key of keys) {
-      const value = metadata.vulnerabilities[key]
-      total = total + value
-    }
-
-    if (total > 0) {
-      exit = 1
-    }
-  }
-
-  exitCode(data.metadata)
-
   return {
-    report: actions(data, config),
-    exitCode: exit
-  }
-}
-
-const getRecommendation = function (action, config) {
-  if (action.action === 'install') {
-    const isDev = action.resolves[0].dev
-
-    return {
-      cmd: `npm install ${isDev ? '--save-dev ' : ''}${action.module}@${action.target}`,
-      isBreaking: action.isMajor
-    }
-  } else {
-    return {
-      cmd: `npm update ${action.module} --depth ${action.depth}`,
-      isBreaking: false
-    }
+    report: vulnTotal ? actions(data, config) : '',
+    exitCode: vulnTotal ? 1 : 0
   }
 }
 

--- a/reporters/quiet.js
+++ b/reporters/quiet.js
@@ -2,12 +2,19 @@
 
 const Utils = require('../lib/utils')
 
-const report = function (data) {
-  const totalVulnCount = Utils.totalVulnCount(data.metadata.vulnerabilities)
+const report = function (data, options) {
+  const defaults = {
+    severityThreshold: 'info'
+  }
+
+  const config = Object.assign({}, defaults, options)
+
+  Utils.vulnFilter(data, config)
+  const vulnTotal = Utils.vulnTotal(data.metadata.vulnerabilities)
 
   return {
     report: '',
-    exitCode: totalVulnCount === 0 ? 0 : 1
+    exitCode: vulnTotal ? 1 : 0
   }
 }
 

--- a/test/detail-report-test.js
+++ b/test/detail-report-test.js
@@ -6,7 +6,7 @@ const fixtures = require('./lib/test-fixtures')
 
 tap.test('it generates a detail report with no vulns', function (t) {
   return Report(fixtures['no-vulns'], {reporter: 'detail', withColor: false}).then((report) => {
-    t.match(report.exitCode, 0, 'successful exit code')
+    t.equal(report.exitCode, 0, 'successful exit code')
     t.match(report.report, /found 0 vulnerabilities/, 'no vulns reported')
     t.match(report.report, /918 scanned packages/, 'reports scanned count')
   })
@@ -98,5 +98,45 @@ tap.test('it generates a detail report with review vulns, no unicode', function 
     t.notMatch(report.report, /┬/, 'unicode table not printed')
     t.match(report.report, /Manual Review/, 'manual review reported')
     t.match(report.report, /1 low, 1 moderate, 1 critical/, 'severity breakdown reported')
+  })
+})
+
+tap.test('it generates a detail report with no vulns when a dev dep has a vuln and dev deps are excluded', function (t) {
+  return Report(fixtures['one-vuln-dev'], {reporter: 'detail', excludeDev: true, withColor: false}).then((report) => {
+    t.equal(report.exitCode, 0, 'successful exit code')
+    t.match(report.report, /found 0 vulnerabilities/, 'no vulns reported')
+    t.match(report.report, /918 scanned packages/, 'reports scanned count')
+  })
+})
+
+tap.test('it generates a detail report with fewer vulns when a severity threshold higher than some vulns is set', function (t) {
+  return Report(fixtures['all-severity-vulns'], {reporter: 'detail', severityThreshold: 'high', withColor: false}).then((report) => {
+    t.equal(report.exitCode, 1, 'non-zero exit code')
+    t.match(report.report, /found 3 vulnerabilities/, 'reports vuln count')
+    t.match(report.report, /2 high, 1 critical/, 'severity breakdown reported')
+  })
+})
+
+tap.test('it generates a detail report with no vulns when a severity threshold higher than all vulns is set', function (t) {
+  return Report(fixtures['some-vulns'], {reporter: 'detail', severityThreshold: 'critical', withColor: false}).then((report) => {
+    t.equal(report.exitCode, 0, 'successful exit code')
+    t.match(report.report, /found 0 vulnerabilities/, 'no vulns reported')
+    t.match(report.report, /918 scanned packages/, 'reports scanned count')
+  })
+})
+
+tap.test('it generates a detail report with one severity threshold', function (t) {
+  return Report(fixtures['all-severity-vulns'], {reporter: 'detail', severityThreshold: 'critical', withColor: false}).then((report) => {
+    t.equal(report.exitCode, 1, 'non-zero exit code')
+    t.match(report.report, /found 1 critical severity vulnerability/, 'one vuln reported')
+    t.match(report.report, /918 scanned packages/, 'reports scanned count')
+  })
+})
+
+tap.test('it generates a detail report with one severity threshold', function (t) {
+  return Report(fixtures['all-severity-vulns-two-crit'], {reporter: 'detail', severityThreshold: 'critical', withColor: false}).then((report) => {
+    t.equal(report.exitCode, 1, 'non-zero exit code')
+    t.match(report.report, /found 2 critical severity vulnerabilities/, 'two vulns one sev')
+    t.match(report.report, /918 scanned packages/, 'reports scanned count')
   })
 })

--- a/test/fixtures/all-severity-vulns-two-crit.json
+++ b/test/fixtures/all-severity-vulns-two-crit.json
@@ -28,18 +28,6 @@
         },
         {
           "id": 534,
-          "path": "standard>eslint>debug",
-          "dev": true,
-          "optional": false
-        },
-        {
-          "id": 534,
-          "path": "standard>eslint>debug",
-          "dev": true,
-          "optional": false
-        },
-        {
-          "id": 534,
           "path": "standard>eslint-plugin-import>debug",
           "dev": true,
           "optional": false
@@ -85,114 +73,6 @@
       "target": "4.2.1",
       "resolves": [
         {
-          "id": 1,
-          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
-          "dev": true,
-          "optional": false
-        },
-        {
-          "id": 1,
-          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
-          "dev": true,
-          "optional": false
-        },
-        {
-          "id": 1,
-          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
-          "dev": true,
-          "optional": false
-        },
-        {
-          "id": 1,
-          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
-          "dev": true,
-          "optional": false
-        },
-        {
-          "id": 1,
-          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
-          "dev": true,
-          "optional": false
-        },
-        {
-          "id": 1,
-          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
-          "dev": true,
-          "optional": false
-        },
-        {
-          "id": 1,
-          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
-          "dev": true,
-          "optional": false
-        },
-        {
-          "id": 1,
-          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
-          "dev": true,
-          "optional": false
-        },
-        {
-          "id": 1,
-          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
-          "dev": true,
-          "optional": false
-        },
-        {
-          "id": 1,
-          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
-          "dev": true,
-          "optional": false
-        },
-        {
-          "id": 1,
-          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
-          "dev": true,
-          "optional": false
-        },
-        {
-          "id": 1,
-          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
-          "dev": true,
-          "optional": false
-        },
-        {
-          "id": 1,
-          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
-          "dev": true,
-          "optional": false
-        },
-        {
-          "id": 1,
-          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
-          "dev": true,
-          "optional": false
-        },
-        {
-          "id": 1,
-          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
-          "dev": true,
-          "optional": false
-        },
-        {
-          "id": 1,
-          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
-          "dev": true,
-          "optional": false
-        },
-        {
-          "id": 157,
-          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
-          "dev": true,
-          "optional": false
-        },
-        {
-          "id": 157,
-          "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
-          "dev": true,
-          "optional": false
-        },
-        {
           "id": 157,
           "path": "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic",
           "dev": true,
@@ -232,55 +112,6 @@
     }
   ],
   "advisories": {
-    "1": {
-      "findings": [
-        {
-          "version": "1.1.7",
-          "paths": [
-            "tap>nyc>micromatch>braces>expand-range>fill-range>randomatic",
-            "tap>nyc>test-exclude>micromatch>braces>expand-range>fill-range>randomatic"
-          ],
-          "dev": true,
-          "optional": false
-        },
-        {
-          "version": "1.1.7",
-          "paths": [
-            "@npm/spife>chokidar>anymatch>micromatch>braces>expand-range>fill-range>randomatic"
-          ],
-          "dev": false,
-          "optional": false
-        }
-      ],
-      "id": 1,
-      "created": "2016-11-09T20:03:19.000Z",
-      "updated": "2018-03-02T23:21:42.009Z",
-      "deleted": null,
-      "title": "Cryptographically Weak PRNG",
-      "found_by": {
-        "name": "Sven Slootweg"
-      },
-      "reported_by": {
-        "name": "Sven Slootweg"
-      },
-      "module_name": "randomatic",
-      "cves": [
-        "CVE-2017-16028"
-      ],
-      "vulnerable_versions": "<3.0.0",
-      "patched_versions": ">=3.0.0",
-      "overview": "Affected versions of `randomatic` generate random values using a cryptographically weak psuedo-random number generator. This may result in predictable values instead of random values as intended.\r\n\r\n",
-      "recommendation": "Update to version 3.0.0 or later.\r\n",
-      "references": "[Commit #4a52695](https://github.com/jonschlinkert/randomatic/commit/4a526959b3a246ae8e4a82f9c182180907227fe1#diff-b9cfc7f2cdf78a7f4b91a753d10865a2)",
-      "access": "public",
-      "severity": "info",
-      "cwe": "CWE-330",
-      "metadata": {
-        "module_type": "Multi.Library",
-        "exploitability": 5,
-        "affected_components": ""
-      }
-    },
     "157": {
       "findings": [
         {
@@ -322,7 +153,7 @@
       "recommendation": "Update to version 3.0.0 or later.\r\n",
       "references": "[Commit #4a52695](https://github.com/jonschlinkert/randomatic/commit/4a526959b3a246ae8e4a82f9c182180907227fe1#diff-b9cfc7f2cdf78a7f4b91a753d10865a2)",
       "access": "public",
-      "severity": "moderate",
+      "severity": "low",
       "cwe": "CWE-330",
       "metadata": {
         "module_type": "Multi.Library",
@@ -362,7 +193,7 @@
       "recommendation": "Please update to version 2.3.3 or greater",
       "references": "- https://github.com/salesforce/tough-cookie/issues/92",
       "access": "public",
-      "severity": "critical",
+      "severity": "high",
       "cwe": "CWE-400",
       "metadata": {
         "module_type": "",
@@ -469,7 +300,7 @@
       "low": 8,
       "moderate": 4,
       "high": 2,
-      "critical": 1
+      "critical": 2
     },
     "dependencies": 375,
     "devDependencies": 466,

--- a/test/reporters-test.js
+++ b/test/reporters-test.js
@@ -3,24 +3,25 @@
 const tap = require('tap')
 const Report = require('../')
 const Keyfob = require('keyfob')
-const {totalVulnCount, severities} = require('../lib/utils')
 const fixtures = Keyfob.load({path: 'test/fixtures', fn: require})
+
+const {vulnTotal, severities} = require('../lib/utils')
 
 tap.test('total vuln count is 0 with no vulns', function (t) {
   return Report(fixtures['no-vulns'], {reporter: 'json'}).then((reportRaw) => {
-    t.equal(totalVulnCount(JSON.parse(reportRaw.report).metadata.vulnerabilities), 0)
+    t.equal(vulnTotal(JSON.parse(reportRaw.report).metadata.vulnerabilities), 0)
   })
 })
 
 tap.test('total vuln count is calculated with some vulns', function (t) {
   return Report(fixtures['some-vulns'], {reporter: 'json'}).then((reportRaw) => {
-    t.equal(totalVulnCount(JSON.parse(reportRaw.report).metadata.vulnerabilities), 12)
+    t.equal(vulnTotal(JSON.parse(reportRaw.report).metadata.vulnerabilities), 12)
   })
 })
 
 tap.test('total vuln count is calculated with all severity vulns', function (t) {
   return Report(fixtures['all-severity-vulns'], {reporter: 'json'}).then((reportRaw) => {
-    t.equal(totalVulnCount(JSON.parse(reportRaw.report).metadata.vulnerabilities), 31)
+    t.equal(vulnTotal(JSON.parse(reportRaw.report).metadata.vulnerabilities), 31)
   })
 })
 

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const tap = require('tap')
-const {severityLabel, color} = require('../lib/utils')
+const {color, severityLabel, severityCompare} = require('../lib/utils')
 
 tap.test('color does just return the value if colorName AND withColor are missing', function (t) {
   t.equal(color('Low'), 'Low')
@@ -17,19 +17,73 @@ tap.test('color returns a formatted string if all params are set', function (t) 
   t.done()
 })
 
-tap.test('severity does not throw an error if given severity is not defined', function (t) {
+tap.test('severityLabel does not throw an error if given severity is not defined', function (t) {
   t.doesNotThrow(function () { severityLabel('me-no-exist') })
   t.done()
 })
 
-tap.test('severity returns a label if there is no color mapping', function (t) {
+tap.test('severityLabel returns a label if there is no color mapping', function (t) {
   t.equal(severityLabel('me-no-exist'), 'Me-no-exist')
   t.equal(severityLabel('w000000t'), 'W000000t')
   t.done()
 })
 
-tap.test('severity returns a label with color formatting ', function (t) {
+tap.test('severityLabel returns a label with color formatting ', function (t) {
   t.equal(severityLabel('high', true, true), '\u001b[91;1mHigh\u001b[0m')
   t.equal(severityLabel('low', true, true), '\u001b[1;1mLow\u001b[0m')
+  t.done()
+})
+
+tap.test('severityCompare does not throw an error if given severity is not defined', function (t) {
+  t.doesNotThrow(function () { severityCompare('low', 'me-no-exist') })
+  t.doesNotThrow(function () { severityCompare('me-no-exist', 'low') })
+  t.done()
+})
+
+tap.test('severityCompare returns 0 when comparing the same severity', function (t) {
+  t.equal(severityCompare('critical', 'critical'), 0)
+  t.equal(severityCompare('high', 'high'), 0)
+  t.equal(severityCompare('moderate', 'moderate'), 0)
+  t.equal(severityCompare('low', 'low'), 0)
+  t.equal(severityCompare('info', 'info'), 0)
+  t.equal(severityCompare('me-no-exist', 'me-no-exist'), 0)
+  t.done()
+})
+
+tap.test('severityCompare returns <0 only when first severity is more severe than 2nd severity', function (t) {
+  t.ok(severityCompare('me-no-exist', 'critical') < 0)
+  t.ok(severityCompare('me-no-exist', 'high') < 0)
+  t.ok(severityCompare('me-no-exist', 'moderate') < 0)
+  t.ok(severityCompare('me-no-exist', 'low') < 0)
+  t.ok(severityCompare('me-no-exist', 'info') < 0)
+  t.ok(severityCompare('critical', 'high') < 0)
+  t.ok(severityCompare('critical', 'moderate') < 0)
+  t.ok(severityCompare('critical', 'low') < 0)
+  t.ok(severityCompare('critical', 'info') < 0)
+  t.ok(severityCompare('high', 'moderate') < 0)
+  t.ok(severityCompare('high', 'low') < 0)
+  t.ok(severityCompare('high', 'info') < 0)
+  t.ok(severityCompare('moderate', 'low') < 0)
+  t.ok(severityCompare('moderate', 'info') < 0)
+  t.ok(severityCompare('low', 'info') < 0)
+  t.done()
+})
+
+tap.test('severityCompare returns >0 only when first severity is less severe than 2nd severity', function (t) {
+  t.ok(severityCompare('info', 'low') > 0)
+  t.ok(severityCompare('info', 'moderate') > 0)
+  t.ok(severityCompare('info', 'high') > 0)
+  t.ok(severityCompare('info', 'critical') > 0)
+  t.ok(severityCompare('info', 'me-no-exist') > 0)
+  t.ok(severityCompare('low', 'moderate') > 0)
+  t.ok(severityCompare('low', 'high') > 0)
+  t.ok(severityCompare('low', 'critical') > 0)
+  t.ok(severityCompare('low', 'me-no-exist') > 0)
+  t.ok(severityCompare('moderate', 'high') > 0)
+  t.ok(severityCompare('moderate', 'critical') > 0)
+  t.ok(severityCompare('moderate', 'me-no-exist') > 0)
+  t.ok(severityCompare('high', 'critical') > 0)
+  t.ok(severityCompare('high', 'me-no-exist') > 0)
+  t.ok(severityCompare('critical', 'me-no-exist') > 0)
   t.done()
 })


### PR DESCRIPTION
I wanted to filter `npm` audit output to see only serious issues, and while searching for how to do that, I landed at [issue #13](https://github.com/npm/npm-audit-report/issues/13).

I saw @welwood08 had said he would take care of it, however his revision was lost in some migration, apparently, and some further searching led me to [his more recent comment](https://github.com/npm/npm-audit-report/issues/31#issuecomment-482277022), inviting anyone else to take over where he left off.

This is the result of my attempt to do so, taking [his feature branch](https://github.com/welwood08/npm-audit-report/tree/exceptions) and comparing it file by file to the `latest` in this repository.

I might be way off when it comes to addressing some concern(s) which people more familiar with npm and its family of projects would know off-hand, if so apologies, but perhaps this can be useful anyhow.  Let me know what might need to be done before it could be accepted and I'll be glad to take some additional passes at it.