### PR TITLE
fix: missing audit data

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,8 @@ const reporters = {
   install: require('./reporters/install'),
   detail: require('./reporters/detail'),
   json: require('./reporters/json'),
-  quiet: require('./reporters/quiet')
+  quiet: require('./reporters/quiet'),
+  warn: require('./reporters/warn')
 }
 
 const exitCode = require('./exit-code.js')
@@ -17,6 +18,12 @@ module.exports = Object.assign((data, options = {}) => {
     indent = 2,
     auditLevel = 'low'
   } = options
+
+  if (!data)
+    return {
+      report: reporters.warn(),
+      exitCode: 0
+    }
 
   if (typeof data.toJSON === 'function')
     data = data.toJSON()

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,8 +4,7 @@ const reporters = {
   install: require('./reporters/install'),
   detail: require('./reporters/detail'),
   json: require('./reporters/json'),
-  quiet: require('./reporters/quiet'),
-  warn: require('./reporters/warn')
+  quiet: require('./reporters/quiet')
 }
 
 const exitCode = require('./exit-code.js')
@@ -20,10 +19,13 @@ module.exports = Object.assign((data, options = {}) => {
   } = options
 
   if (!data)
-    return {
-      report: reporters.warn(),
-      exitCode: 0
-    }
+    throw Object.assign(
+      new TypeError('ENOAUDITDATA'),
+      {
+        code: 'ENOAUDITDATA',
+        message: 'missing audit data'
+      }
+    )
 
   if (typeof data.toJSON === 'function')
     data = data.toJSON()

--- a/lib/reporters/warn.js
+++ b/lib/reporters/warn.js
@@ -1,0 +1,1 @@
+module.exports = () => 'No audit report found'

--- a/lib/reporters/warn.js
+++ b/lib/reporters/warn.js
@@ -1,1 +1,0 @@
-module.exports = () => 'No audit report found'

--- a/test/index.js
+++ b/test/index.js
@@ -7,6 +7,7 @@ t.equal(nar.reporters.install, require('../lib/reporters/install.js'))
 t.equal(nar.reporters.detail, require('../lib/reporters/detail.js'))
 t.equal(nar.reporters.json, require('../lib/reporters/json.js'))
 t.equal(nar.reporters.quiet, require('../lib/reporters/quiet.js'))
+t.equal(nar.reporters.warn, require('../lib/reporters/warn.js'))
 
 const metadata = { vulnerabilities: {} }
 const fake = { reporter: 'fake' }
@@ -41,4 +42,11 @@ t.test('install is default reporter', async t => {
     unicode: true,
     indent: 2,
   }))
+})
+
+t.test('falsy audit data', async t => {
+  t.strictSame(nar(null), {
+    exitCode: 0,
+    report: 'No audit report found',
+  }, 'should report a warning message')
 })

--- a/test/index.js
+++ b/test/index.js
@@ -7,7 +7,6 @@ t.equal(nar.reporters.install, require('../lib/reporters/install.js'))
 t.equal(nar.reporters.detail, require('../lib/reporters/detail.js'))
 t.equal(nar.reporters.json, require('../lib/reporters/json.js'))
 t.equal(nar.reporters.quiet, require('../lib/reporters/quiet.js'))
-t.equal(nar.reporters.warn, require('../lib/reporters/warn.js'))
 
 const metadata = { vulnerabilities: {} }
 const fake = { reporter: 'fake' }
@@ -44,9 +43,11 @@ t.test('install is default reporter', async t => {
   }))
 })
 
-t.test('falsy audit data', async t => {
-  t.strictSame(nar(null), {
-    exitCode: 0,
-    report: 'No audit report found',
-  }, 'should report a warning message')
+t.test('falsy audit data', t => {
+  t.throws(
+    () => nar(),
+    { code: 'ENOAUDITDATA' },
+    'should throw a missing audit data error'
+  )
+  t.end()
 })


### PR DESCRIPTION
Currently when trying to install with the cli using `--no-audit` will result in the audit report failing with a: `TypeError: Cannot read property 'toJSON' of null` error.

~This change avoids this unexpected error by reporting a warning message letting the user aware that the audit data is missing.~

This PR adds throwing a new `TypeError` whenever the user tries to use the audit report while missing audit data.