### PR TITLE
fix(exit-code): account for null default

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,8 +15,10 @@ module.exports = Object.assign((data, options = {}) => {
     color = true,
     unicode = true,
     indent = 2,
-    auditLevel = 'low'
   } = options
+
+  // CLI defaults this to `null` so the defaulting method above doesn't work
+  const auditLevel = options.auditLevel || 'low'
 
   if (!data)
     throw Object.assign(

--- a/test/index.js
+++ b/test/index.js
@@ -9,6 +9,15 @@ t.equal(nar.reporters.json, require('../lib/reporters/json.js'))
 t.equal(nar.reporters.quiet, require('../lib/reporters/quiet.js'))
 
 const metadata = { vulnerabilities: {} }
+const highMeta = {
+  vulnerabilities: {
+    high: 99,
+    low: 0,
+    critical: 0,
+    total: 99
+  }
+}
+
 const fake = { reporter: 'fake' }
 t.strictSame(nar({ foo: 'bar', metadata }, fake), {
   exitCode: 0,
@@ -33,6 +42,18 @@ t.strictSame(nar({ foo: 'bar', toJSON: () => ({ bar: 'baz', metadata }) }, fake)
     },
   }
 }, 'should call toJSON')
+
+t.strictSame(nar({ foo: 'bar', auditLevel: null, metadata: highMeta }, fake), {
+  exitCode: 1,
+  report: {
+    data: { foo: 'bar', auditLevel: null, metadata: highMeta },
+    options: {
+      color: true,
+      unicode: true,
+      indent: 2,
+    },
+  }
+}, 'null auditLevel')
 
 t.test('install is default reporter', async t => {
   const fix = fixture('one-vuln')


### PR DESCRIPTION
The cli passes in `null` here, so we have to default it with a truthiness check, not a property check.


## References
Closes https://github.com/npm/cli/issues/2868